### PR TITLE
Dropeo de pociones, cartel y mejora de boss

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -22,11 +22,11 @@
   </component>
   <component name="FileEditorManager">
     <leaf>
-      <file leaf-file-name="Jefe.js" pinned="false" current-in-tab="false">
+      <file leaf-file-name="Jefe.js" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/src/Jefe.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.0">
-              <caret line="16" column="31" selection-start-line="16" selection-start-column="31" selection-end-line="16" selection-end-column="31" />
+            <state vertical-scroll-proportion="0.5255023">
+              <caret line="98" column="72" selection-start-line="98" selection-start-column="72" selection-end-line="98" selection-end-column="72" />
               <folding />
             </state>
           </provider>
@@ -35,28 +35,18 @@
       <file leaf-file-name="GameScene.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/GameScene.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.0">
-              <caret line="356" column="50" selection-start-line="356" selection-start-column="24" selection-end-line="356" selection-end-column="50" />
+            <state vertical-scroll-proportion="-13.551724">
+              <caret line="408" column="27" selection-start-line="408" selection-start-column="27" selection-end-line="408" selection-end-column="27" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="Enemigo.js" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.6846986">
-              <caret line="118" column="9" selection-start-line="118" selection-start-column="9" selection-end-line="118" selection-end-column="9" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="Pocion.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/Pocion.js">
+      <file leaf-file-name="ControlesLayer.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/ControlesLayer.js">
           <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="5" column="20" selection-start-line="5" selection-start-column="20" selection-end-line="5" selection-end-column="20" />
+              <caret line="36" column="7" selection-start-line="36" selection-start-column="7" selection-end-line="36" selection-end-column="7" />
               <folding />
             </state>
           </provider>
@@ -66,7 +56,27 @@
         <entry file="file://$PROJECT_DIR$/src/Palanca.js">
           <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+              <caret line="49" column="47" selection-start-line="49" selection-start-column="47" selection-end-line="49" selection-end-column="47" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Cartel.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Cartel.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="0.0">
+              <caret line="30" column="29" selection-start-line="30" selection-start-column="29" selection-end-line="30" selection-end-column="29" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Enemigo.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="0.0">
+              <caret line="103" column="40" selection-start-line="103" selection-start-column="40" selection-end-line="103" selection-end-column="40" />
               <folding />
             </state>
           </provider>
@@ -92,16 +102,6 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="project.json" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/project.json">
-          <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.0">
-              <caret line="16" column="27" selection-start-line="16" selection-start-column="27" selection-end-line="17" selection-end-column="25" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
     </leaf>
   </component>
   <component name="GradleLocalSettings">
@@ -114,10 +114,13 @@
       <list>
         <option value="$PROJECT_DIR$/main.js" />
         <option value="$PROJECT_DIR$/src/Caballero.js" />
-        <option value="$PROJECT_DIR$/project.json" />
-        <option value="$PROJECT_DIR$/src/Jefe.js" />
-        <option value="$PROJECT_DIR$/src/GameScene.js" />
         <option value="$PROJECT_DIR$/src/Enemigo.js" />
+        <option value="$PROJECT_DIR$/project.json" />
+        <option value="$PROJECT_DIR$/src/ControlesLayer.js" />
+        <option value="$PROJECT_DIR$/src/Palanca.js" />
+        <option value="$PROJECT_DIR$/src/Cartel.js" />
+        <option value="$PROJECT_DIR$/src/GameScene.js" />
+        <option value="$PROJECT_DIR$/src/Jefe.js" />
       </list>
     </option>
   </component>
@@ -371,7 +374,7 @@
     <servers />
   </component>
   <component name="ToolWindowManager">
-    <frame x="-8" y="-8" width="1382" height="784" extended-state="6" />
+    <frame x="-8" y="-8" width="1382" height="784" extended-state="7" />
     <editor active="true" />
     <layout>
       <window_info id="Palette" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
@@ -442,21 +445,6 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/src/app.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/GameScene.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/project.json">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
@@ -491,6 +479,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
         </state>
       </provider>
     </entry>
@@ -536,6 +525,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
         </state>
       </provider>
     </entry>
@@ -581,6 +571,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
         </state>
       </provider>
     </entry>
@@ -626,6 +617,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
         </state>
       </provider>
     </entry>
@@ -671,6 +663,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
         </state>
       </provider>
     </entry>
@@ -708,6 +701,7 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
         </state>
       </provider>
     </entry>
@@ -742,36 +736,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/app.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/resource.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/project.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="16" column="27" selection-start-line="16" selection-start-column="27" selection-end-line="17" selection-end-column="25" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Palanca.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/Puerta.js">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
@@ -795,34 +759,82 @@
         </state>
       </provider>
     </entry>
+    <entry file="file://$PROJECT_DIR$/src/resource.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/app.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project.json">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.68438005">
+          <caret line="25" column="23" selection-start-line="25" selection-start-column="23" selection-end-line="25" selection-end-column="23" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
     <entry file="file://$PROJECT_DIR$/src/Pocion.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="5" column="20" selection-start-line="5" selection-start-column="20" selection-end-line="5" selection-end-column="20" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Jefe.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="16" column="31" selection-start-line="16" selection-start-column="31" selection-end-line="16" selection-end-column="31" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/GameScene.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="356" column="50" selection-start-line="356" selection-start-column="24" selection-end-line="356" selection-end-column="50" />
+        <state vertical-scroll-proportion="0.8423493">
+          <caret line="52" column="3" selection-start-line="0" selection-start-column="0" selection-end-line="52" selection-end-column="3" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.6846986">
-          <caret line="118" column="9" selection-start-line="118" selection-start-column="9" selection-end-line="118" selection-end-column="9" />
+        <state vertical-scroll-proportion="0.0">
+          <caret line="103" column="40" selection-start-line="103" selection-start-column="40" selection-end-line="103" selection-end-column="40" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ControlesLayer.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="36" column="7" selection-start-line="36" selection-start-column="7" selection-end-line="36" selection-end-column="7" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Cartel.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="30" column="29" selection-start-line="30" selection-start-column="29" selection-end-line="30" selection-end-column="29" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Palanca.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="49" column="47" selection-start-line="49" selection-start-column="47" selection-end-line="49" selection-end-column="47" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/GameScene.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-13.551724">
+          <caret line="408" column="27" selection-start-line="408" selection-start-column="27" selection-end-line="408" selection-end-column="27" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Jefe.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.5255023">
+          <caret line="98" column="72" selection-start-line="98" selection-start-column="72" selection-end-line="98" selection-end-column="72" />
           <folding />
         </state>
       </provider>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -26,27 +26,37 @@
         <entry file="file://$PROJECT_DIR$/src/Jefe.js">
           <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="79" column="46" selection-start-line="79" selection-start-column="46" selection-end-line="79" selection-end-column="46" />
+              <caret line="16" column="31" selection-start-line="16" selection-start-column="31" selection-end-line="16" selection-end-column="31" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="GameScene.js" pinned="false" current-in-tab="true">
+      <file leaf-file-name="GameScene.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/GameScene.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.41262135">
-              <caret line="101" column="72" selection-start-line="101" selection-start-column="72" selection-end-line="101" selection-end-column="72" />
+            <state vertical-scroll-proportion="0.0">
+              <caret line="356" column="50" selection-start-line="356" selection-start-column="24" selection-end-line="356" selection-end-column="50" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="Enemigo.js" pinned="false" current-in-tab="false">
+      <file leaf-file-name="Enemigo.js" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
           <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="0.6846986">
+              <caret line="118" column="9" selection-start-line="118" selection-start-column="9" selection-end-line="118" selection-end-column="9" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Pocion.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Pocion.js">
+          <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="69" column="7" selection-start-line="69" selection-start-column="7" selection-end-line="69" selection-end-column="7" />
+              <caret line="5" column="20" selection-start-line="5" selection-start-column="20" selection-end-line="5" selection-end-column="20" />
               <folding />
             </state>
           </provider>
@@ -107,6 +117,7 @@
         <option value="$PROJECT_DIR$/project.json" />
         <option value="$PROJECT_DIR$/src/Jefe.js" />
         <option value="$PROJECT_DIR$/src/GameScene.js" />
+        <option value="$PROJECT_DIR$/src/Enemigo.js" />
       </list>
     </option>
   </component>
@@ -142,8 +153,6 @@
       <sortByType />
     </navigator>
     <panes>
-      <pane id="Scope" />
-      <pane id="Scratches" />
       <pane id="ProjectPane">
         <subPane>
           <PATH>
@@ -178,6 +187,8 @@
           </PATH>
         </subPane>
       </pane>
+      <pane id="Scratches" />
+      <pane id="Scope" />
       <pane id="PackagesPane" />
     </panes>
   </component>
@@ -361,18 +372,18 @@
   </component>
   <component name="ToolWindowManager">
     <frame x="-8" y="-8" width="1382" height="784" extended-state="6" />
-    <editor active="false" />
+    <editor active="true" />
     <layout>
       <window_info id="Palette" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="TODO" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="6" side_tool="false" content_ui="tabs" />
       <window_info id="Palette&#9;" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="2" side_tool="false" content_ui="tabs" />
-      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
+      <window_info id="Event Log" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.3288889" sideWeight="0.5" order="7" side_tool="true" content_ui="tabs" />
       <window_info id="Application Servers" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Maven Projects" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Version Control" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Terminal" active="false" anchor="bottom" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="7" side_tool="false" content_ui="tabs" />
       <window_info id="Designer" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
-      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.23054332" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+      <window_info id="Project" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" weight="0.22986823" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
       <window_info id="LuaJ" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
       <window_info id="Structure" active="false" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
       <window_info id="Ant Build" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.25" sideWeight="0.5" order="1" side_tool="false" content_ui="tabs" />
@@ -431,19 +442,10 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/src/Caballero.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="286" column="0" selection-start-line="286" selection-start-column="0" selection-end-line="286" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/app.js">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -475,7 +477,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="63" column="42" selection-start-line="63" selection-start-column="42" selection-end-line="63" selection-end-column="42" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -483,7 +484,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="286" column="0" selection-start-line="286" selection-start-column="0" selection-end-line="286" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -491,7 +491,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -523,7 +522,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="63" column="42" selection-start-line="63" selection-start-column="42" selection-end-line="63" selection-end-column="42" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -531,7 +529,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="161" column="0" selection-start-line="161" selection-start-column="0" selection-end-line="161" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -539,7 +536,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -571,7 +567,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="63" column="42" selection-start-line="63" selection-start-column="42" selection-end-line="63" selection-end-column="42" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -579,7 +574,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="161" column="0" selection-start-line="161" selection-start-column="0" selection-end-line="161" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -587,7 +581,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -619,7 +612,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="63" column="42" selection-start-line="63" selection-start-column="42" selection-end-line="63" selection-end-column="42" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -627,7 +619,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="161" column="0" selection-start-line="161" selection-start-column="0" selection-end-line="161" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -635,7 +626,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -667,7 +657,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="63" column="42" selection-start-line="63" selection-start-column="42" selection-end-line="63" selection-end-column="42" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -675,7 +664,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="161" column="0" selection-start-line="161" selection-start-column="0" selection-end-line="161" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -683,7 +671,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -707,7 +694,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="63" column="42" selection-start-line="63" selection-start-column="42" selection-end-line="63" selection-end-column="42" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -715,7 +701,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="142" column="0" selection-start-line="142" selection-start-column="0" selection-end-line="142" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -723,7 +708,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -755,7 +739,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="286" column="0" selection-start-line="286" selection-start-column="0" selection-end-line="286" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -763,7 +746,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -810,14 +792,13 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.76352394">
           <caret line="63" column="42" selection-start-line="63" selection-start-column="42" selection-end-line="63" selection-end-column="42" />
-          <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
+    <entry file="file://$PROJECT_DIR$/src/Pocion.js">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
-          <caret line="69" column="7" selection-start-line="69" selection-start-column="7" selection-end-line="69" selection-end-column="7" />
+          <caret line="5" column="20" selection-start-line="5" selection-start-column="20" selection-end-line="5" selection-end-column="20" />
           <folding />
         </state>
       </provider>
@@ -825,15 +806,23 @@
     <entry file="file://$PROJECT_DIR$/src/Jefe.js">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
-          <caret line="79" column="46" selection-start-line="79" selection-start-column="46" selection-end-line="79" selection-end-column="46" />
+          <caret line="16" column="31" selection-start-line="16" selection-start-column="31" selection-end-line="16" selection-end-column="31" />
           <folding />
         </state>
       </provider>
     </entry>
     <entry file="file://$PROJECT_DIR$/src/GameScene.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.41262135">
-          <caret line="101" column="72" selection-start-line="101" selection-start-column="72" selection-end-line="101" selection-end-column="72" />
+        <state vertical-scroll-proportion="0.0">
+          <caret line="356" column="50" selection-start-line="356" selection-start-column="24" selection-end-line="356" selection-end-column="50" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.6846986">
+          <caret line="118" column="9" selection-start-line="118" selection-start-column="9" selection-end-line="118" selection-end-column="9" />
           <folding />
         </state>
       </provider>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -22,11 +22,11 @@
   </component>
   <component name="FileEditorManager">
     <leaf>
-      <file leaf-file-name="Jefe.js" pinned="false" current-in-tab="true">
+      <file leaf-file-name="Jefe.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Jefe.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.5255023">
-              <caret line="98" column="72" selection-start-line="98" selection-start-column="72" selection-end-line="98" selection-end-column="72" />
+            <state vertical-scroll-proportion="0.0">
+              <caret line="103" column="0" selection-start-line="103" selection-start-column="0" selection-end-line="103" selection-end-column="0" />
               <folding />
             </state>
           </provider>
@@ -35,8 +35,18 @@
       <file leaf-file-name="GameScene.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/GameScene.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="-13.551724">
-              <caret line="408" column="27" selection-start-line="408" selection-start-column="27" selection-end-line="408" selection-end-column="27" />
+            <state vertical-scroll-proportion="16.793104">
+              <caret line="131" column="35" selection-start-line="131" selection-start-column="35" selection-end-line="131" selection-end-column="35" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Caballero.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Caballero.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="0.0">
+              <caret line="18" column="29" selection-start-line="18" selection-start-column="29" selection-end-line="18" selection-end-column="29" />
               <folding />
             </state>
           </provider>
@@ -46,37 +56,47 @@
         <entry file="file://$PROJECT_DIR$/src/ControlesLayer.js">
           <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="36" column="7" selection-start-line="36" selection-start-column="7" selection-end-line="36" selection-end-column="7" />
+              <caret line="35" column="8" selection-start-line="35" selection-start-column="8" selection-end-line="35" selection-end-column="8" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="Palanca.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/Palanca.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.0">
-              <caret line="49" column="47" selection-start-line="49" selection-start-column="47" selection-end-line="49" selection-end-column="47" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="Cartel.js" pinned="false" current-in-tab="false">
+      <file leaf-file-name="Cartel.js" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/src/Cartel.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.0">
-              <caret line="30" column="29" selection-start-line="30" selection-start-column="29" selection-end-line="30" selection-end-column="29" />
+            <state vertical-scroll-proportion="0.3431221">
+              <caret line="27" column="45" selection-start-line="27" selection-start-column="45" selection-end-line="27" selection-end-column="45" />
               <folding />
             </state>
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="Enemigo.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
+      <file leaf-file-name="project.json" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/project.json">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="-17.0">
+              <caret line="26" column="22" selection-start-line="26" selection-start-column="22" selection-end-line="26" selection-end-column="22" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Llave.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Llave.js">
           <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="103" column="40" selection-start-line="103" selection-start-column="40" selection-end-line="103" selection-end-column="40" />
+              <caret line="31" column="30" selection-start-line="31" selection-start-column="30" selection-end-line="31" selection-end-column="30" />
+              <folding />
+            </state>
+          </provider>
+        </entry>
+      </file>
+      <file leaf-file-name="Pocion.js" pinned="false" current-in-tab="false">
+        <entry file="file://$PROJECT_DIR$/src/Pocion.js">
+          <provider selected="true" editor-type-id="text-editor">
+            <state vertical-scroll-proportion="0.0">
+              <caret line="36" column="0" selection-start-line="36" selection-start-column="0" selection-end-line="36" selection-end-column="0" />
               <folding />
             </state>
           </provider>
@@ -86,17 +106,7 @@
         <entry file="file://$PROJECT_DIR$/src/Puerta.js">
           <provider selected="true" editor-type-id="text-editor">
             <state vertical-scroll-proportion="0.0">
-              <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-              <folding />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="Vela.js" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/src/Vela.js">
-          <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.0">
-              <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
+              <caret line="106" column="64" selection-start-line="106" selection-start-column="64" selection-end-line="106" selection-end-column="64" />
               <folding />
             </state>
           </provider>
@@ -114,13 +124,15 @@
       <list>
         <option value="$PROJECT_DIR$/main.js" />
         <option value="$PROJECT_DIR$/src/Caballero.js" />
+        <option value="$PROJECT_DIR$/src/Palanca.js" />
+        <option value="$PROJECT_DIR$/src/Jefe.js" />
         <option value="$PROJECT_DIR$/src/Enemigo.js" />
         <option value="$PROJECT_DIR$/project.json" />
+        <option value="$PROJECT_DIR$/src/Llave.js" />
         <option value="$PROJECT_DIR$/src/ControlesLayer.js" />
-        <option value="$PROJECT_DIR$/src/Palanca.js" />
-        <option value="$PROJECT_DIR$/src/Cartel.js" />
         <option value="$PROJECT_DIR$/src/GameScene.js" />
-        <option value="$PROJECT_DIR$/src/Jefe.js" />
+        <option value="$PROJECT_DIR$/src/Puerta.js" />
+        <option value="$PROJECT_DIR$/src/Cartel.js" />
       </list>
     </option>
   </component>
@@ -190,9 +202,9 @@
           </PATH>
         </subPane>
       </pane>
-      <pane id="Scratches" />
-      <pane id="Scope" />
       <pane id="PackagesPane" />
+      <pane id="Scope" />
+      <pane id="Scratches" />
     </panes>
   </component>
   <component name="PropertiesComponent">
@@ -374,7 +386,7 @@
     <servers />
   </component>
   <component name="ToolWindowManager">
-    <frame x="-8" y="-8" width="1382" height="784" extended-state="7" />
+    <frame x="-8" y="-8" width="1382" height="784" extended-state="6" />
     <editor active="true" />
     <layout>
       <window_info id="Palette" active="false" anchor="right" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="false" weight="0.33" sideWeight="0.5" order="3" side_tool="false" content_ui="tabs" />
@@ -445,19 +457,10 @@
     <watches-manager />
   </component>
   <component name="editorHistoryManager">
-    <entry file="file://$PROJECT_DIR$/project.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="16" column="27" selection-start-line="16" selection-start-column="27" selection-end-line="17" selection-end-column="25" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/index.html">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -479,7 +482,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -503,7 +505,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -525,7 +526,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -549,7 +549,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -571,7 +570,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -595,7 +593,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -617,7 +614,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -641,7 +637,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -663,7 +658,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -679,7 +673,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -701,7 +694,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -717,7 +709,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -725,22 +716,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Caballero.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="286" column="0" selection-start-line="286" selection-start-column="0" selection-end-line="286" selection-end-column="0" />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Puerta.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -763,7 +738,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -771,47 +745,6 @@
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
           <caret line="0" column="0" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/project.json">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.68438005">
-          <caret line="25" column="23" selection-start-line="25" selection-start-column="23" selection-end-line="25" selection-end-column="23" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Pocion.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.8423493">
-          <caret line="52" column="3" selection-start-line="0" selection-start-column="0" selection-end-line="52" selection-end-column="3" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="103" column="40" selection-start-line="103" selection-start-column="40" selection-end-line="103" selection-end-column="40" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/ControlesLayer.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="36" column="7" selection-start-line="36" selection-start-column="7" selection-end-line="36" selection-end-column="7" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
-    <entry file="file://$PROJECT_DIR$/src/Cartel.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.0">
-          <caret line="30" column="29" selection-start-line="30" selection-start-column="29" selection-end-line="30" selection-end-column="29" />
-          <folding />
         </state>
       </provider>
     </entry>
@@ -823,18 +756,82 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/GameScene.js">
+    <entry file="file://$PROJECT_DIR$/src/Jefe.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="-13.551724">
-          <caret line="408" column="27" selection-start-line="408" selection-start-column="27" selection-end-line="408" selection-end-column="27" />
+        <state vertical-scroll-proportion="0.0">
+          <caret line="103" column="0" selection-start-line="103" selection-start-column="0" selection-end-line="103" selection-end-column="0" />
           <folding />
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/Jefe.js">
+    <entry file="file://$PROJECT_DIR$/src/Enemigo.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.5255023">
-          <caret line="98" column="72" selection-start-line="98" selection-start-column="72" selection-end-line="98" selection-end-column="72" />
+        <state vertical-scroll-proportion="0.6846986">
+          <caret line="122" column="23" selection-start-line="122" selection-start-column="23" selection-end-line="122" selection-end-column="23" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/project.json">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="-17.0">
+          <caret line="26" column="22" selection-start-line="26" selection-start-column="22" selection-end-line="26" selection-end-column="22" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/ControlesLayer.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="35" column="8" selection-start-line="35" selection-start-column="8" selection-end-line="35" selection-end-column="8" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Caballero.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="18" column="29" selection-start-line="18" selection-start-column="29" selection-end-line="18" selection-end-column="29" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Pocion.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="36" column="0" selection-start-line="36" selection-start-column="0" selection-end-line="36" selection-end-column="0" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/GameScene.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="16.793104">
+          <caret line="131" column="35" selection-start-line="131" selection-start-column="35" selection-end-line="131" selection-end-column="35" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Puerta.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="106" column="64" selection-start-line="106" selection-start-column="64" selection-end-line="106" selection-end-column="64" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Llave.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.0">
+          <caret line="31" column="30" selection-start-line="31" selection-start-column="30" selection-end-line="31" selection-end-column="30" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/Cartel.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.3431221">
+          <caret line="27" column="45" selection-start-line="27" selection-start-column="45" selection-end-line="27" selection-end-column="45" />
           <folding />
         </state>
       </provider>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -32,11 +32,11 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="GameScene.js" pinned="false" current-in-tab="false">
+      <file leaf-file-name="GameScene.js" pinned="false" current-in-tab="true">
         <entry file="file://$PROJECT_DIR$/src/GameScene.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="16.793104">
-              <caret line="131" column="35" selection-start-line="131" selection-start-column="35" selection-end-line="131" selection-end-column="35" />
+            <state vertical-scroll-proportion="0.28478965">
+              <caret line="479" column="30" selection-start-line="479" selection-start-column="30" selection-end-line="479" selection-end-column="30" />
               <folding />
             </state>
           </provider>
@@ -62,11 +62,11 @@
           </provider>
         </entry>
       </file>
-      <file leaf-file-name="Cartel.js" pinned="false" current-in-tab="true">
+      <file leaf-file-name="Cartel.js" pinned="false" current-in-tab="false">
         <entry file="file://$PROJECT_DIR$/src/Cartel.js">
           <provider selected="true" editor-type-id="text-editor">
-            <state vertical-scroll-proportion="0.3431221">
-              <caret line="27" column="45" selection-start-line="27" selection-start-column="45" selection-end-line="27" selection-end-column="45" />
+            <state vertical-scroll-proportion="0.0">
+              <caret line="33" column="54" selection-start-line="33" selection-start-column="54" selection-end-line="33" selection-end-column="54" />
               <folding />
             </state>
           </provider>
@@ -130,9 +130,9 @@
         <option value="$PROJECT_DIR$/project.json" />
         <option value="$PROJECT_DIR$/src/Llave.js" />
         <option value="$PROJECT_DIR$/src/ControlesLayer.js" />
-        <option value="$PROJECT_DIR$/src/GameScene.js" />
         <option value="$PROJECT_DIR$/src/Puerta.js" />
         <option value="$PROJECT_DIR$/src/Cartel.js" />
+        <option value="$PROJECT_DIR$/src/GameScene.js" />
       </list>
     </option>
   </component>
@@ -804,14 +804,6 @@
         </state>
       </provider>
     </entry>
-    <entry file="file://$PROJECT_DIR$/src/GameScene.js">
-      <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="16.793104">
-          <caret line="131" column="35" selection-start-line="131" selection-start-column="35" selection-end-line="131" selection-end-column="35" />
-          <folding />
-        </state>
-      </provider>
-    </entry>
     <entry file="file://$PROJECT_DIR$/src/Puerta.js">
       <provider selected="true" editor-type-id="text-editor">
         <state vertical-scroll-proportion="0.0">
@@ -830,8 +822,16 @@
     </entry>
     <entry file="file://$PROJECT_DIR$/src/Cartel.js">
       <provider selected="true" editor-type-id="text-editor">
-        <state vertical-scroll-proportion="0.3431221">
-          <caret line="27" column="45" selection-start-line="27" selection-start-column="45" selection-end-line="27" selection-end-column="45" />
+        <state vertical-scroll-proportion="0.0">
+          <caret line="33" column="54" selection-start-line="33" selection-start-column="54" selection-end-line="33" selection-end-column="54" />
+          <folding />
+        </state>
+      </provider>
+    </entry>
+    <entry file="file://$PROJECT_DIR$/src/GameScene.js">
+      <provider selected="true" editor-type-id="text-editor">
+        <state vertical-scroll-proportion="0.28478965">
+          <caret line="479" column="30" selection-start-line="479" selection-start-column="30" selection-end-line="479" selection-end-column="30" />
           <folding />
         </state>
       </provider>

--- a/project.json
+++ b/project.json
@@ -23,6 +23,7 @@
         "src/Jefe.js",
         "src/Pocion.js",
         "src/DisparoJefe.js",
-        "src/Cartel.js"
+        "src/Cartel.js",
+        "src/Llave.js"
     ]
 }

--- a/project.json
+++ b/project.json
@@ -22,6 +22,7 @@
         "src/ControlesLayer.js",
         "src/Jefe.js",
         "src/Pocion.js",
-        "src/DisparoJefe.js"
+        "src/DisparoJefe.js",
+        "src/Cartel.js"
     ]
 }

--- a/res/mazmorra.tmx
+++ b/res/mazmorra.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="32" tileheight="32" nextobjectid="100">
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="32" tileheight="32" nextobjectid="101">
  <tileset firstgid="1" name="Elementos" tilewidth="32" tileheight="32" tilecount="100" columns="10">
   <image source="Elementos.png" width="322" height="320"/>
  </tileset>
@@ -116,6 +116,9 @@
   <object id="49" x="976.591" y="1902.82" width="31.6364" height="32"/>
   <object id="50" x="1008.77" y="1903" width="31.6364" height="31.8182"/>
   <object id="51" x="1040.64" y="1902.94" width="30.9091" height="31.8182"/>
+ </objectgroup>
+ <objectgroup name="Cartel">
+  <object id="100" x="1151" y="1627" width="38" height="35"/>
  </objectgroup>
  <objectgroup name="PuertasJefe">
   <object id="52" x="944.364" y="883.5" width="31.4545" height="32"/>

--- a/res/mazmorra.tmx
+++ b/res/mazmorra.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="32" tileheight="32" nextobjectid="101">
+<map version="1.0" tiledversion="1.0.3" orientation="orthogonal" renderorder="right-down" width="100" height="100" tilewidth="32" tileheight="32" nextobjectid="109">
  <tileset firstgid="1" name="Elementos" tilewidth="32" tileheight="32" tilecount="100" columns="10">
   <image source="Elementos.png" width="322" height="320"/>
  </tileset>
@@ -170,6 +170,9 @@
   </object>
   <object id="81" x="1183.33" y="1439">
    <polyline points="0,0 -31.3333,-0.333333 -31.3333,56 0.666667,56 0.333333,-0.666667"/>
+  </object>
+  <object id="108" x="1139" y="1614">
+   <polyline points="0,0 0,55 65,54 63,-2 1,-1"/>
   </object>
  </objectgroup>
 </map>

--- a/src/Cartel.js
+++ b/src/Cartel.js
@@ -1,0 +1,53 @@
+var Cartel = cc.Class.extend({
+    gameLayer:null,
+    sprite:null,
+    body:null,
+    shape:null,
+ctor:function (gameLayer, posicion) {
+    this.gameLayer = gameLayer;
+    // Crear animación
+    var framesAnimacion = [];
+    for (var i = 1; i <= 1; i++) {
+        var str = "pocion_normal_" + i + ".png";
+        var frame = cc.spriteFrameCache.getSpriteFrame(str);
+        framesAnimacion.push(frame);
+    }
+    var animacion = new cc.Animation(framesAnimacion, 0.2);
+    this.actionAnimacionNormal =
+        new cc.RepeatForever(new cc.Animate(animacion));
+
+
+    // Crear Sprite - Cuerpo y forma
+    this.sprite = new cc.PhysicsSprite("#pocion_normal_1.png");
+
+    // Cuerpo estático , no le afectan las fuerzas
+    var body = new cp.StaticBody();
+    body.setPos(posicion);
+    this.sprite.setBody(body);
+    // forma
+    this.shape = new cp.BoxShape(body,31,31);
+    this.shape.setCollisionType(tipoCartel);
+    // agregar forma dinamica
+    gameLayer.space.addStaticShape(this.shape);
+    // añadir sprite a la capa
+
+    this.sprite.runAction(this.actionAnimacionNormal);
+    this.animacion = this.actionAnimacionNormal;
+
+
+
+    gameLayer.addChild(this.sprite,10);
+}, update:function (dt) {
+      this.sprite.runAction(this.actionAnimacionNormal);
+}, eliminar: function (){
+         // quita la forma
+         this.gameLayer.space.removeShape(this.shape);
+
+         // quita el cuerpo *opcional, funciona igual
+         // NO: es un cuerpo estático, no lo añadimos, no se puede quitar.
+         // this.gameLayer.space.removeBody(shape.getBody());
+
+         // quita el sprite
+         this.gameLayer.removeChild(this.sprite);
+     }
+});

--- a/src/ControlesLayer.js
+++ b/src/ControlesLayer.js
@@ -1,6 +1,7 @@
 var ControlesLayer = cc.Layer.extend({
     etiquetaVidas:null,
     etiquetaAcertijo:null,
+    etiquetaLlaves:null,
     mostrando:false,
     ctor:function () {
         this._super();
@@ -11,6 +12,11 @@ var ControlesLayer = cc.Layer.extend({
         this.etiquetaVidas.setPosition(cc.p(size.width - 750, size.height - 20));
         this.etiquetaVidas.fillStyle = new cc.Color(255, 255, 255, 255);
         this.addChild(this.etiquetaVidas)
+
+        this.etiquetaLlaves = new cc.LabelTTF("Llaves: 0", "Helvetica", 20);
+        this.etiquetaLlaves.setPosition(cc.p(size.width*0.92, size.height*0.95));
+        this.etiquetaLlaves.fillStyle = new cc.Color(255, 255, 255, 255);
+        this.addChild(this.etiquetaLlaves)
 
         this.etiquetaAcertijo = new cc.LabelTTF("Abajo Abajo Arriba Arriba Derecha Izquierda Derecha Izquierda.\n" +
         "No repitas en el mismo eje", "Helvetica", 20);
@@ -23,11 +29,16 @@ var ControlesLayer = cc.Layer.extend({
 
     },quitarVida:function(vidas){
          this.etiquetaVidas.setString("Vidas: " + vidas);
+     },añadirLlave:function(llaves){
+         this.etiquetaLlaves.setString("Llaves: " + llaves);
+
+     },quitarLlave:function(llaves){
+        this.etiquetaLlaves.setString("Llaves: " + llaves);
      },mostrarAcertijo:function(){
-            if(!this.mostrando){
-                this.addChild(this.etiquetaAcertijo)
-            }
-            this.mostrando = true;
+         if(!this.mostrando){
+             this.addChild(this.etiquetaAcertijo)
+         }
+         this.mostrando = true;
      }
      ,quitarAcertijo:function(){
              if(this.mostrando){

--- a/src/ControlesLayer.js
+++ b/src/ControlesLayer.js
@@ -1,5 +1,7 @@
 var ControlesLayer = cc.Layer.extend({
     etiquetaVidas:null,
+    etiquetaAcertijo:null,
+    mostrando:false,
     ctor:function () {
         this._super();
         var size = cc.winSize;
@@ -8,7 +10,12 @@ var ControlesLayer = cc.Layer.extend({
         this.etiquetaVidas = new cc.LabelTTF("Vidas: 3", "Helvetica", 20);
         this.etiquetaVidas.setPosition(cc.p(size.width - 750, size.height - 20));
         this.etiquetaVidas.fillStyle = new cc.Color(255, 255, 255, 255);
-        this.addChild(this.etiquetaVidas);
+        this.addChild(this.etiquetaVidas)
+
+        this.etiquetaAcertijo = new cc.LabelTTF("Abajo Abajo Arriba Arriba Derecha Izquierda Derecha Izquierda.\n" +
+        "No repitas en el mismo eje", "Helvetica", 20);
+        this.etiquetaAcertijo.setPosition(cc.p(size.width - size.width*0.5, size.height - size.height*0.8));
+        this.etiquetaAcertijo.fillStyle = new cc.Color(255, 255, 255, 255);
 
         this.scheduleUpdate();
         return true;
@@ -16,5 +23,16 @@ var ControlesLayer = cc.Layer.extend({
 
     },quitarVida:function(vidas){
          this.etiquetaVidas.setString("Vidas: " + vidas);
+     },mostrarAcertijo:function(){
+            if(!this.mostrando){
+                this.addChild(this.etiquetaAcertijo)
+            }
+            this.mostrando = true;
      }
+     ,quitarAcertijo:function(){
+             if(this.mostrando){
+                 this.removeChild(this.etiquetaAcertijo)
+             }
+             this.mostrando = false;
+      }
 });

--- a/src/Enemigo.js
+++ b/src/Enemigo.js
@@ -5,9 +5,12 @@ var Enemigo = cc.Class.extend({
     animacion:null,
     sprite:null,
     shape:null,
-ctor:function (gameLayer, posicion, drop) {
+    dropKey:null,
+    dropPotion:null,
+ctor:function (gameLayer, posicion, drop, dropKey) {
     this.gameLayer = gameLayer;
     this.dropPotion = drop;
+    this.dropKey = dropKey;
     // Crear animación
     var framesAnimacion = [];
     for (var i = 1; i <= 6; i++) {
@@ -116,6 +119,10 @@ ctor:function (gameLayer, posicion, drop) {
         if(this.dropPotion){
             var pocion = new Pocion(this.gameLayer,cc.p(this.body.p.x,this.body.p.y));
             this.gameLayer.pociones.push(pocion)
+        }
+        if(this.dropKey){
+            var llave = new Llave(this.gameLayer,cc.p(this.body.p.x,this.body.p.y));
+            this.gameLayer.llaves.push(llave)
         }
     }
 

--- a/src/Enemigo.js
+++ b/src/Enemigo.js
@@ -5,9 +5,9 @@ var Enemigo = cc.Class.extend({
     animacion:null,
     sprite:null,
     shape:null,
-ctor:function (gameLayer, posicion) {
+ctor:function (gameLayer, posicion, drop) {
     this.gameLayer = gameLayer;
-
+    this.dropPotion = drop;
     // Crear animación
     var framesAnimacion = [];
     for (var i = 1; i <= 6; i++) {
@@ -113,6 +113,10 @@ ctor:function (gameLayer, posicion) {
 
         // quita el sprite
         this.gameLayer.removeChild(this.sprite);
+        if(this.dropPotion){
+            var pocion = new Pocion(this.gameLayer,cc.p(this.body.p.x,this.body.p.y));
+            this.gameLayer.pociones.push(pocion)
+        }
     }
 
 

--- a/src/GameScene.js
+++ b/src/GameScene.js
@@ -7,6 +7,7 @@ var tipoSuelo = 6;
 var tipoPocion = 7;
 var tipoDisparo = 8;
 var tipoJefe = 9;
+var tipoCartel = 10;
 
 var GameLayer = cc.Layer.extend({
     caballero:null,
@@ -32,6 +33,7 @@ var GameLayer = cc.Layer.extend({
     sol:[],
     jefe:null,
     pociones:[],
+    cartel:null,
     ctor:function () {
 
        this._super();
@@ -73,9 +75,13 @@ var GameLayer = cc.Layer.extend({
        this.space.addCollisionHandler(tipoJefe,tipoSuelo,
                        null, this.collisionEnemigoConSuelo.bind(this),null,null);
        this.space.addCollisionHandler(tipoJugador,tipoJefe,
-                              null, this.collisionJugadorConJefe.bind(this),null,null);
-      this.space.addCollisionHandler(tipoDisparo,tipoPocion,
-                                    null, this.collisionDisparoConPocion.bind(this),null,null);
+                        null, this.collisionJugadorConJefe.bind(this),null,null);
+       this.space.addCollisionHandler(tipoDisparo,tipoPocion,
+                        null, this.collisionDisparoConPocion.bind(this),null,null);
+       this.space.addCollisionHandler(tipoJugador,tipoCartel,
+                        null, this.collisionJugadorConCartel.bind(this),null,null);
+       this.space.addCollisionHandler(tipoJefe,tipoPocion,
+                        null, this.collisionJefeConPocion.bind(this),null,null);
        this.cargarMapa();
        this.scheduleUpdate();
 
@@ -238,6 +244,8 @@ var GameLayer = cc.Layer.extend({
             }
        }
        if(this.tecla == 32){
+            var capaControles = this.getParent().getChildByTag(idCapaControles);
+            capaControles.quitarAcertijo();
             this.caballero.atacar();
        }
 
@@ -356,6 +364,14 @@ var GameLayer = cc.Layer.extend({
                                 cc.p(pocionesNArray[i]["x"],pocionesNArray[i]["y"]));
                         this.pociones.push(pocion);
                 }
+
+          var grupoCartel = this.mapa.getObjectGroup("Cartel");
+                         var cartelArray = grupoCartel.getObjects();
+                             for (var i = 0; i < cartelArray.length; i++) {
+                                 var cartel = new Cartel(this,
+                                         cc.p(cartelArray[i]["x"],cartelArray[i]["y"]));
+                                 this.cartel = cartel;
+                         }
     },teclaPulsada: function(keyCode, event){
          var instancia = event.getCurrentTarget();
 
@@ -390,6 +406,7 @@ var GameLayer = cc.Layer.extend({
 
     },collisionJugadorConPuertaNormal:function (arbiter, space) {}
     ,collisionJugadorConPuertaJefe:function (arbiter, space) {}
+    ,collisionJefeConPocion:function (arbiter, space) {}
     ,collisionJugadorConPalanca:function (arbiter, space) {
             if(!this.accionadas && this.eliminados){
                 var palanca = arbiter.getShapes();
@@ -434,6 +451,10 @@ var GameLayer = cc.Layer.extend({
     ,collisionDisparoConSuelo:function(arbiter, space){}
     ,collisionEnemigoConSuelo:function (arbiter, space){
         this.jefe.body.vx = this.jefe.body.vx*-1;
+    }
+    ,collisionJugadorConCartel:function (arbiter, space){
+            var capaControles = this.getParent().getChildByTag(idCapaControles);
+            capaControles.mostrarAcertijo();
     }
     ,collisionJugadorConPocion:function (arbiter, space) {
             var shapes = arbiter.getShapes();

--- a/src/GameScene.js
+++ b/src/GameScene.js
@@ -477,8 +477,10 @@ var GameLayer = cc.Layer.extend({
         this.jefe.body.vx = this.jefe.body.vx*-1;
     }
     ,collisionJugadorConCartel:function (arbiter, space){
-            var capaControles = this.getParent().getChildByTag(idCapaControles);
-            capaControles.mostrarAcertijo();
+            if(this.caballero.atacando){
+                var capaControles = this.getParent().getChildByTag(idCapaControles);
+                capaControles.mostrarAcertijo();
+            }
     }
     ,collisionJugadorConPocion:function (arbiter, space) {
             var shapes = arbiter.getShapes();

--- a/src/GameScene.js
+++ b/src/GameScene.js
@@ -74,6 +74,8 @@ var GameLayer = cc.Layer.extend({
                        null, this.collisionEnemigoConSuelo.bind(this),null,null);
        this.space.addCollisionHandler(tipoJugador,tipoJefe,
                               null, this.collisionJugadorConJefe.bind(this),null,null);
+      this.space.addCollisionHandler(tipoDisparo,tipoPocion,
+                                    null, this.collisionDisparoConPocion.bind(this),null,null);
        this.cargarMapa();
        this.scheduleUpdate();
 
@@ -85,9 +87,9 @@ var GameLayer = cc.Layer.extend({
         if(this.jefe == null){
             this.jefe = new Jefe(this,cc.p(522,2960));
         }
-       var enemigo = new Enemigo(this,cc.p(1200,700));
+       var enemigo = new Enemigo(this,cc.p(1200,700), true);
        this.enemigos.push(enemigo);
-       enemigo = new Enemigo(this,cc.p(650,1000));
+       enemigo = new Enemigo(this,cc.p(650,1000), false);
        this.enemigos.push(enemigo);
 
        cc.eventManager.addListener({
@@ -426,6 +428,7 @@ var GameLayer = cc.Layer.extend({
                      }
                   }
          }
+    ,collisionDisparoConPocion:function (arbiter,space){}
     ,collisionEnemigoConDisparoJefe:function (arbiter,space){}
     ,collisionDisparoConDisparo:function (arbiter,space){}
     ,collisionDisparoConSuelo:function(arbiter, space){}

--- a/src/GameScene.js
+++ b/src/GameScene.js
@@ -8,6 +8,7 @@ var tipoPocion = 7;
 var tipoDisparo = 8;
 var tipoJefe = 9;
 var tipoCartel = 10;
+var tipoLlave = 11;
 
 var GameLayer = cc.Layer.extend({
     caballero:null,
@@ -33,7 +34,9 @@ var GameLayer = cc.Layer.extend({
     sol:[],
     jefe:null,
     pociones:[],
+    llaves:[],
     cartel:null,
+    numllaves:0,
     ctor:function () {
 
        this._super();
@@ -82,6 +85,8 @@ var GameLayer = cc.Layer.extend({
                         null, this.collisionJugadorConCartel.bind(this),null,null);
        this.space.addCollisionHandler(tipoJefe,tipoPocion,
                         null, this.collisionJefeConPocion.bind(this),null,null);
+       this.space.addCollisionHandler(tipoJugador,tipoLlave,
+                        null, this.collisionJugadorConLlave.bind(this),null,null);
        this.cargarMapa();
        this.scheduleUpdate();
 
@@ -93,9 +98,9 @@ var GameLayer = cc.Layer.extend({
         if(this.jefe == null){
             this.jefe = new Jefe(this,cc.p(522,2960));
         }
-       var enemigo = new Enemigo(this,cc.p(1200,700), true);
+       var enemigo = new Enemigo(this,cc.p(1200,700), true, false);
        this.enemigos.push(enemigo);
-       enemigo = new Enemigo(this,cc.p(650,1000), false);
+       enemigo = new Enemigo(this,cc.p(650,1000), false, true);
        this.enemigos.push(enemigo);
 
        cc.eventManager.addListener({
@@ -131,7 +136,7 @@ var GameLayer = cc.Layer.extend({
             this.eliminados = false;
         }
         for(var i=0;i<this.puertasN.length;i++){
-            this.puertasN[i].updateNormal(dt,this.eliminados)
+            this.puertasN[i].updateNormal(dt,this.eliminados,this.llaves.length ,this.numllaves)
         }
         if(this.combinacion && this.inicio){
             for(var i=0;i<this.puertasJ.length;i++){
@@ -140,7 +145,6 @@ var GameLayer = cc.Layer.extend({
         }
         var correcto = false;
         if(this.caballero.body.p.y > 2070){
-
             correcto = true;
         }
         if(this.caballero.body.p.y > 2325){
@@ -271,6 +275,12 @@ var GameLayer = cc.Layer.extend({
                 if (this.pociones[i].shape == shape) {
                     this.pociones[i].eliminar();
                     this.pociones.splice(i, 1);
+                }
+            }
+            for (var i = 0; i < this.llaves.length; i++) {
+                if (this.llaves[i].shape == shape) {
+                    this.llaves[i].eliminar();
+                    this.llaves.splice(i, 1);
                 }
             }
             if(this.disparo != null && this.disparo.shape == shape){
@@ -404,7 +414,21 @@ var GameLayer = cc.Layer.extend({
                     }
                  }
 
-    },collisionJugadorConPuertaNormal:function (arbiter, space) {}
+    },collisionJugadorConPuertaNormal:function (arbiter, space) {
+        if(this.numllaves > 0){
+            this.numllaves--;
+            console.log(this.numllaves);
+            var capaControles = this.getParent().getChildByTag(idCapaControles);
+            capaControles.quitarLlave(this.numllaves);
+        }
+    },collisionJugadorConPuertaNormal:function (arbiter, space) {
+             if(this.numllaves > 0){
+                 this.numllaves--;
+                 console.log(this.numllaves);
+                 var capaControles = this.getParent().getChildByTag(idCapaControles);
+                 capaControles.quitarLlave(this.numllaves);
+             }
+         }
     ,collisionJugadorConPuertaJefe:function (arbiter, space) {}
     ,collisionJefeConPocion:function (arbiter, space) {}
     ,collisionJugadorConPalanca:function (arbiter, space) {
@@ -475,6 +499,13 @@ var GameLayer = cc.Layer.extend({
             var shapes = arbiter.getShapes();
             // shapes[0] es el jugador
             this.formasEliminar.push(shapes[1]);
+       },collisionJugadorConLlave:function (arbiter,space){
+            var shapes = arbiter.getShapes();
+            // shapes[0] es el jugador
+            this.numllaves++;
+            this.formasEliminar.push(shapes[1]);
+            var capaControles = this.getParent().getChildByTag(idCapaControles);
+            capaControles.añadirLlave(this.numllaves);
        }
 });
 

--- a/src/Jefe.js
+++ b/src/Jefe.js
@@ -16,7 +16,7 @@ var Jefe = cc.Class.extend({
 ctor:function (gameLayer, posicion) {
     this.gameLayer = gameLayer;
     this.tiempoEntreDisparos = 2;
-    this.vidas = 60;
+    this.vidas = 120;
     this.vidasInicial = this.vidas;
     this.fase=false;
     this.velocidad = 300;

--- a/src/Jefe.js
+++ b/src/Jefe.js
@@ -95,10 +95,12 @@ ctor:function (gameLayer, posicion) {
                 this.sprite.runAction(this.animacion);
       }
       if(this.vidas <= this.vidasInicial /2 ){
-              if(!this.fase)
-                  this.tiempoEntreDisparos = this.tiempoEntreDisparos -0.1;
+              if(!this.fase){
+                  this.tiempoEntreDisparos = this.tiempoEntreDisparos /2;
+                  this.body.vx = this.body.vx * 1.5
+              }
               this.fase = true;
-            }
+      }
 
   },quitarVida:function(){
         this.vidas--;

--- a/src/Llave.js
+++ b/src/Llave.js
@@ -1,0 +1,53 @@
+var Llave = cc.Class.extend({
+    gameLayer:null,
+    sprite:null,
+    body:null,
+    shape:null,
+ctor:function (gameLayer, posicion) {
+    this.gameLayer = gameLayer;
+    // Crear animación
+    var framesAnimacion = [];
+    for (var i = 1; i <= 1; i++) {
+        var str = "pocion_normal_" + i + ".png";
+        var frame = cc.spriteFrameCache.getSpriteFrame(str);
+        framesAnimacion.push(frame);
+    }
+    var animacion = new cc.Animation(framesAnimacion, 0.2);
+    this.actionAnimacionNormal =
+        new cc.RepeatForever(new cc.Animate(animacion));
+
+
+    // Crear Sprite - Cuerpo y forma
+    this.sprite = new cc.PhysicsSprite("#pocion_normal_1.png");
+
+    // Cuerpo estático , no le afectan las fuerzas
+    var body = new cp.StaticBody();
+    body.setPos(posicion);
+    this.sprite.setBody(body);
+    // forma
+    this.shape = new cp.BoxShape(body,31,31);
+    this.shape.setCollisionType(tipoLlave);
+    // agregar forma dinamica
+    gameLayer.space.addShape(this.shape);
+    // añadir sprite a la capa
+
+    this.sprite.runAction(this.actionAnimacionNormal);
+    this.animacion = this.actionAnimacionNormal;
+
+
+
+    gameLayer.addChild(this.sprite,10);
+}, update:function (dt) {
+      this.sprite.runAction(this.actionAnimacionNormal);
+}, eliminar: function (){
+         // quita la forma
+         this.gameLayer.space.removeShape(this.shape);
+
+         // quita el cuerpo *opcional, funciona igual
+         // NO: es un cuerpo estático, no lo añadimos, no se puede quitar.
+         // this.gameLayer.space.removeBody(shape.getBody());
+
+         // quita el sprite
+         this.gameLayer.removeChild(this.sprite);
+     }
+});

--- a/src/Palanca.js
+++ b/src/Palanca.js
@@ -45,12 +45,6 @@ ctor:function (gameLayer, posicion, id) {
     // forma
     this.shape = new cp.BoxShape(body,32,38);
     this.shape.setCollisionType(tipoPalanca);
-    /*if(this.tipo==1){
-        this.shape.setCollisionType(tipoPuertaNormal);
-    }
-    if(this.tipo==2){
-        this.shape.setCollisionType(tipoPuertaJefe);
-    }*/
 
     // agregar forma dinamica
     gameLayer.space.addStaticShape(this.shape);

--- a/src/Puerta.js
+++ b/src/Puerta.js
@@ -93,15 +93,20 @@ ctor:function (gameLayer, posicion,tipo) {
 
 
     gameLayer.addChild(this.sprite,10);
-}, updateNormal:function (dt, correcto) {
+}, updateNormal:function (dt, correcto, llaves, numllaves) {
 
       // aumentar el tiempo que ha pasado desde el ultimo salto
-      if(correcto){
+      if(correcto && llaves == 0 && numllaves == 0){
             if(this.tipo == 1){
                 this.sprite.runAction(this.actionAnimacionNormalAbierta);
                 this.shape.setCollisionType(tipoPuertaNormal);
             }
       }
+      if(correcto && llaves == 0 && numllaves > 0){
+              if(this.tipo == 1){
+                  this.shape.setCollisionType(tipoPuertaNormal);
+              }
+       }
       if(!correcto){
             if(this.tipo == 1){
                 this.sprite.runAction(this.actionAnimacionNormalCerrada);


### PR DESCRIPTION
Los enemigos dropean pociones. En los commit explico como hacer que lo hagan
El cartel está añadida funcionalidad menos imagen (use pocion para pruebas) y funciona. Se activa el texto al tocarlo y se quita al atacar. No se como hacerlo físico.
El boss tiene más vida y, cuando se pone bajo de vida, se enfada y dispara más rápido y se mueve más rápido.